### PR TITLE
Adopt new Slack API

### DIFF
--- a/example/cloud-functions/config.yaml
+++ b/example/cloud-functions/config.yaml
@@ -25,9 +25,6 @@ queries:
   # url: $SLACK_WEBHOOK_URL (Define SLACK_WEBHOOK_URL by the environment valiable)
 # Or you can also define global slack settings
 slack:
-  channel: test
   title: クエリの結果です
   color: good # good or danger or warning
-  username: bqnotifybot
-  iconurl: https://avatars0.githubusercontent.com/u/7151005
   # url: $SLACK_WEBHOOK_URL (Define SLACK_WEBHOOK_URL by the environment valiable)

--- a/lib/notify/slack.go
+++ b/lib/notify/slack.go
@@ -9,12 +9,9 @@ import (
 
 // Slack has configurations for notifying to Slack
 type Slack struct {
-	Channel  string `json:"channel"`
-	URL      string `json:"-"`
-	IconURL  string `json:"icon_url"`
-	UserName string `json:"username"`
-	Title    string `json:"title"`
-	Color    string `json:"color"`
+	URL   string `json:"-"`
+	Title string `json:"title"`
+	Color string `json:"color"`
 }
 
 type payload struct {
@@ -29,10 +26,6 @@ type attachment struct {
 
 // Notify notifies BigQuery query results to Slack
 func (s Slack) Notify(message string) error {
-	if s.Channel[0] != '#' {
-		s.Channel = "#" + s.Channel
-	}
-
 	color := s.Color
 
 	a := attachment{


### PR DESCRIPTION
 Because recent Slack app incoming webhook does not need these settings.