### PR TITLE
Write a query result to a table that has an expiration

### DIFF
--- a/lib/bq/bq.go
+++ b/lib/bq/bq.go
@@ -3,41 +3,70 @@ package bq
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/aktsk/bqnotify/lib/config"
 	"google.golang.org/api/iterator"
 )
 
+type Result struct {
+	Headers   []string
+	Rows      [][]string
+	DatasetID string
+	TableID   string
+}
+
 // Query runs queries to BigQuery and return results
-func Query(project string, query config.Query) ([]string, [][]string, error) {
+func Query(project string, query config.Query) (*Result, error) {
 	ctx := context.Background()
 
 	client, err := bigquery.NewClient(ctx, project)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	defer client.Close()
 
 	q := client.Query(query.SQL)
 
+	var datasetID string
+	var tableID string
+
+	// Write the query result to the table specified in config.yaml
+	if query.ResultTable != nil {
+		datasetID = query.ResultTable.DatasetID
+		tableID = fmt.Sprintf("%s%s", query.ResultTable.TableIDPrefix, time.Now().Format("20060102150405"))
+
+		// Create dataset if it does not exist
+		metadata, _ := client.Dataset(datasetID).Metadata(ctx)
+		if metadata == nil {
+			err := client.Dataset(datasetID).Create(ctx, &bigquery.DatasetMetadata{})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// Set the destination table to write the query result
+		q.QueryConfig.Dst = client.Dataset(datasetID).Table(tableID)
+	}
+
 	job, err := q.Run(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	status, err := job.Wait(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if err := status.Err(); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	it, err := job.Read(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	headers := []string{}
@@ -56,7 +85,7 @@ func Query(project string, query config.Query) ([]string, [][]string, error) {
 		}
 
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		values := []string{}
@@ -66,5 +95,33 @@ func Query(project string, query config.Query) ([]string, [][]string, error) {
 		rows = append(rows, values)
 	}
 
-	return headers, rows, nil
+	// Set expiration time to the result table
+	if query.ResultTable != nil {
+		tableRef := client.Dataset(datasetID).Table(tableID)
+
+		meta, err := tableRef.Metadata(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if query.ResultTable.ExpirationInDays == 0 {
+			query.ResultTable.ExpirationInDays = 30
+		}
+
+		update := bigquery.TableMetadataToUpdate{
+			ExpirationTime: time.Now().Add(time.Duration(query.ResultTable.ExpirationInDays*24) * time.Hour),
+		}
+
+		_, err = tableRef.Update(ctx, update, meta.ETag)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Result{
+		Headers:   headers,
+		Rows:      rows,
+		DatasetID: datasetID,
+		TableID:   tableID,
+	}, nil
 }

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -17,8 +17,15 @@ type Config struct {
 }
 
 type Query struct {
-	SQL   string
-	Slack *notify.Slack
+	SQL         string
+	Slack       *notify.Slack
+	ResultTable *ResultTable `yaml:"result_table"`
+}
+
+type ResultTable struct {
+	DatasetID        string `yaml:"dataset_id"`
+	TableIDPrefix    string `yaml:"table_id_prefix"`
+	ExpirationInDays int    `yaml:"expiration_in_days"`
 }
 
 // Parse parses config.yaml


### PR DESCRIPTION
## 目的

クエリ結果を有効期限つきのテーブルに書き込むための実装を行います。

以下のようにconfig.yamlで`result_table`を設定すると、指定されたテーブルにクエリ結果を書き込みます。

```yaml
queries:
- sql: |-
    SELECT
      gender,
      COUNT(*) AS rides,
      AVG(tripduration / 60) AS avg_trip_duration
    FROM
      `bigquery-public-data`.new_york_citibike.citibike_trips
    WHERE
      tripduration IS NOT NULL
    GROUP BY
      gender
    ORDER BY
      avg_trip_duration
  slack:
    title: クエリの結果です
    color: good # good or danger or warning
  result_table:
    dataset_id: query_results
    table_id_prefix: query_result_
    expiration_in_days: 1
```

- `result_table`を設定しない場合は、クエリ結果のテーブルへの書き込みは行いません。
- テーブル名は、`table_id_prefix`で設定した文字列に日時を付与したものになります。（例: query_result_20241018081530）
- `expiration_in_days`を指定しない場合は、デフォルトで30日の期限を設定します。

## 動作確認スクリーンショット

#### Slackへの通知

<img width="972" alt="スクリーンショット 2024-10-18 8 02 55" src="https://github.com/user-attachments/assets/d4eb7bde-74c2-4eaf-9259-70b122eb3e58">

#### 結果テーブルのスキーマ

<img width="1177" alt="スクリーンショット 2024-10-18 8 05 13" src="https://github.com/user-attachments/assets/fc5e3e34-4822-4cfb-bb64-1a58481b2029">

#### 結果テーブルの有効期限

<img width="1177" alt="スクリーンショット 2024-10-18 8 06 15" src="https://github.com/user-attachments/assets/1c89c9ef-57f0-4856-b0c4-984cea7069b6">

#### 結果テーブル内のデータ

<img width="1177" alt="スクリーンショット 2024-10-18 8 07 30" src="https://github.com/user-attachments/assets/2b64ecd6-98ab-4646-8deb-0fb354b9778b">

